### PR TITLE
 	Soporte para NET 4.0 en versión 1.0.0-alpha2 

### DIFF
--- a/src/Jaguar.Reporting.Html.csproj
+++ b/src/Jaguar.Reporting.Html.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="Jaguar.Reporting" Version="1.0.0-beta6" />
+    <PackageReference Include="Jaguar.Reporting" Version="1.0.0-beta7" />
     <PackageReference Include="mustache-sharp-core" Version="1.0.1-alpha1" />
   </ItemGroup>
 

--- a/src/Jaguar.Reporting.Html.csproj
+++ b/src/Jaguar.Reporting.Html.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>net40;netcoreapp1.1</TargetFrameworks>
     <RootNamespace>Jaguar.Reporting.Generators</RootNamespace>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Carlos Jesús Huchim Ahumada</Authors>
@@ -10,7 +10,7 @@
     <Copyright>Carlos Jesús Huchim Ahumada</Copyright>
     <PackageTags>reporting</PackageTags>
     <PackageReleaseNotes>Beta</PackageReleaseNotes>
-    <Version>1.0.0-alpha1</Version>
+    <Version>1.0.0-alpha2</Version>
     <PackageProjectUrl>https://github.com/huchim/reporting-html</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/huchim/reporting-html/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/huchim/reporting-html</RepositoryUrl>
@@ -18,7 +18,12 @@
     <RootNamespace>Jaguar.Reporting</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="Jaguar.Reporting" Version="1.0.0-beta7" />
+    <PackageReference Include="mustache-sharp" Version="0.2.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Jaguar.Reporting" Version="1.0.0-beta6" />
     <PackageReference Include="mustache-sharp-core" Version="1.0.1-alpha1" />
   </ItemGroup>


### PR DESCRIPTION
gregar soporte para los proyectos hechos en .NET40. No hubo problemas al compilar.